### PR TITLE
ci: update node versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 16, 'current']
+        node-version: [12, 14, 16,]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes the failing CI workflow by replacing the `current` Node version with `14`.